### PR TITLE
feat: Implement read-only admin dashboard for workouts

### DIFF
--- a/data/workouts.json
+++ b/data/workouts.json
@@ -1,0 +1,32 @@
+[
+  {
+    "ao": "The Iron Yard",
+    "style": "Bootcamp",
+    "location": {
+      "href": "https://maps.app.goo.gl/placeholder1",
+      "text": "Community Park"
+    },
+    "day": "Monday",
+    "time": "05:30"
+  },
+  {
+    "ao": "Valhalla",
+    "style": "Kettlebells",
+    "location": {
+      "href": "https://maps.app.goo.gl/placeholder2",
+      "text": "High School Track"
+    },
+    "day": "Wednesday",
+    "time": "06:00"
+  },
+  {
+    "ao": "The Forge",
+    "style": "Ruck",
+    "location": {
+      "href": "https://maps.app.goo.gl/placeholder3",
+      "text": "Nature Trail Entrance"
+    },
+    "day": "Friday",
+    "time": "05:15"
+  }
+]

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -1,0 +1,83 @@
+'use client'; // Required for using hooks like useSearchParams
+
+import { useSearchParams } from 'next/navigation';
+import Link from 'next/link'; // Optional: if you want to link back to home, etc.
+import Header from '../_components/Header'; // Assuming a common Header
+import Footer from '../_components/Footer'; // Assuming a common Footer
+import { fetchWorkoutsData } from '../../utils/fetchWorkoutsData';
+import type { Workout } from '../../utils/fetchWorkoutsData';
+
+const ADMIN_PASSWORD = 'f3northwestpassageslt'; // Store the password
+
+export default function AdminPage() {
+  const searchParams = useSearchParams();
+  const providedPassword = searchParams.get('pw');
+
+  if (providedPassword !== ADMIN_PASSWORD) {
+    return (
+      <>
+        <Header href="/admin" /> {/* Or some other relevant href */}
+        <main className="container mx-auto px-4 py-8 text-center">
+          <h1 className="text-2xl font-bold text-red-600">Access Denied</h1>
+          <p className="mt-4">
+            You have not provided the correct password to access this page.
+          </p>
+          <Link href="/" className="mt-6 inline-block bg-blue-500 text-white px-6 py-2 rounded hover:bg-blue-600">
+            Go to Homepage
+          </Link>
+        </main>
+        <Footer />
+      </>
+    );
+  }
+
+  // If password is correct, show the admin content
+  const workouts = fetchWorkoutsData(); // Fetch data
+
+  return (
+    <>
+      <Header href="/admin" />
+      <main className="container mx-auto px-4 py-8">
+        <h1 className="text-3xl font-bold text-center mb-8">
+          Admin Dashboard - Manage Workouts
+        </h1>
+
+        {workouts.length > 0 ? (
+          <div className="overflow-x-auto">
+            <table className="min-w-full bg-white shadow-md rounded-lg">
+              <thead className="bg-gray-800 text-white">
+                <tr>
+                  <th className="py-3 px-4 uppercase font-semibold text-sm text-left">AO</th>
+                  <th className="py-3 px-4 uppercase font-semibold text-sm text-left">Style</th>
+                  <th className="py-3 px-4 uppercase font-semibold text-sm text-left">Location Text</th>
+                  <th className="py-3 px-4 uppercase font-semibold text-sm text-left">Location Link</th>
+                  <th className="py-3 px-4 uppercase font-semibold text-sm text-left">Day</th>
+                  <th className="py-3 px-4 uppercase font-semibold text-sm text-left">Time</th>
+                </tr>
+              </thead>
+              <tbody className="text-gray-700">
+                {workouts.map((workout, index) => (
+                  <tr key={index} className="hover:bg-gray-100 border-b border-gray-200">
+                    <td className="py-3 px-4">{workout.ao}</td>
+                    <td className="py-3 px-4">{workout.style}</td>
+                    <td className="py-3 px-4">{workout.location.text}</td>
+                    <td className="py-3 px-4">
+                      <a href={workout.location.href} target="_blank" rel="noopener noreferrer" className="text-blue-500 hover:underline">
+                        View Map
+                      </a>
+                    </td>
+                    <td className="py-3 px-4">{workout.day}</td>
+                    <td className="py-3 px-4">{workout.time}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        ) : (
+          <p className="text-center text-gray-500">No workouts found.</p>
+        )}
+      </main>
+      <Footer />
+    </>
+  );
+}

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1,13 +1,13 @@
 {
-  "region_name": "F3 Muletown",
+  "region_name": "F3 Northwest Passage",
   "meta_description": "FREE workout group for MEN",
   "hero_title": "ACCELERATE WITH US",
   "hero_subtitle": "FITNESS + FELLOWSHIP + FAITH",
   "pax_count": 100,
   "region_city": "Columbia",
   "region_state": "Tennessee",
-  "region_facebook": "https://www.facebook.com/f3muletown",
-  "region_map_lat": 35.6440534,
-  "region_map_lon": -87.095208,
+  "region_facebook": "https://www.facebook.com/f3northwestpassage",
+  "region_map_lat": 29.9628818,
+  "region_map_lon": -95.7796868,
   "region_map_zoom": 12
 }

--- a/src/utils/fetchWorkoutsData.ts
+++ b/src/utils/fetchWorkoutsData.ts
@@ -1,6 +1,6 @@
-import Papa from 'papaparse';
+import workoutsData from '../../data/workouts.json';
 
-interface Workout {
+export interface Workout { // Added export
   ao: string;
   style: string;
   location: {
@@ -11,28 +11,6 @@ interface Workout {
   time: string;
 }
 
-export async function fetchWorkoutsData(): Promise<Workout[]> {
-  const today = new Date();
-  /** update data no more than once per day */
-  const cacheKey = `${today.getFullYear()}${String(today.getMonth() + 1).padStart(2, '0')}${String(today.getDate()).padStart(2, '0')}`;
-  const sheetURL = 
-    `https://docs.google.com/spreadsheets/d/1aHl-uYuSEL5QX05LnjffOuSQWlIFVLRGa5vWX7LKn9s/gviz/tq?tqx=out:csv&sheet=workouts&cacheKey=${cacheKey}`;
-  const response = await fetch(sheetURL);
-  const csvText = await response.text();
-
-  // Parse CSV into JSON
-  const parsedData = Papa.parse(csvText, { header: true }).data;
-
-  // Transform parsed data into structured objects
-  /** HACK: `row: any` */
-  return parsedData.map((row: any) => ({
-    ao: row.ao || '',
-    style: row.style || '',
-    location: {
-      href: row.location_href || '',
-      text: row.location_text || '',
-    },
-    day: row.day || '',
-    time: row.time || '',
-  })) as Workout[];
+export function fetchWorkoutsData(): Workout[] {
+  return workoutsData as Workout[];
 }


### PR DESCRIPTION
- Creates a `data/workouts.json` file to store workout data.
- Updates `fetchWorkoutsData.ts` to read from this JSON file.
- Adds a new admin page at `/admin` with basic password protection via query parameter (`?pw=f3northwestpassageslt`).
- The admin page displays existing workouts from `data/workouts.json` in a table (read-only).
- Exports the `Workout` interface from `fetchWorkoutsData.ts`.