### PR TITLE
feat: Disable GA and make admin password configurable

### DIFF
--- a/src/app/api/workouts/route.ts
+++ b/src/app/api/workouts/route.ts
@@ -3,17 +3,33 @@ import fs from 'fs';
 import path from 'path';
 import type { Workout } from '../../../utils/fetchWorkoutsData'; // Adjust path as needed
 
-const ADMIN_PASSWORD = 'f3northwestpassageslt'; // Same password as admin page
+// const ADMIN_PASSWORD = 'f3northwestpassageslt'; // REMOVE THIS LINE
 
 export async function POST(request: NextRequest) {
-  // Password check from URL query parameter
+  let localeAdminPassword;
+  try {
+    const localeFilePath = path.join(process.cwd(), 'src', 'locales', 'en.json');
+    const fileContents = fs.readFileSync(localeFilePath, 'utf-8');
+    const localeData = JSON.parse(fileContents);
+    localeAdminPassword = localeData.admin_password;
+
+    if (!localeAdminPassword) {
+      console.error('Admin password not found in src/locales/en.json or is empty.');
+      return NextResponse.json({ message: 'Error: Server configuration error (admin password missing).' }, { status: 500 });
+    }
+  } catch (error) {
+    console.error('Error reading or parsing src/locales/en.json for admin password:', error);
+    return NextResponse.json({ message: 'Error: Server configuration error (cannot read admin password).' }, { status: 500 });
+  }
+
   const { searchParams } = new URL(request.url);
   const providedPassword = searchParams.get('pw');
 
-  if (providedPassword !== ADMIN_PASSWORD) {
+  if (providedPassword !== localeAdminPassword) { // COMPARE WITH PASSWORD FROM JSON
     return NextResponse.json({ message: 'Error: Access Denied. Invalid password.' }, { status: 403 });
   }
 
+  // ... (rest of the try-catch block for saving workouts remains the same)
   try {
     const workouts: Workout[] = await request.json();
 

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -10,6 +10,7 @@ export default function Layout({ children }: { children: React.ReactNode }) {
       <head>
         <link rel="shortcut icon" href="/favicon.ico" />
         <meta name="robots" content="noindex,nofollow" />
+        {/*
         <Script
           src="https://www.googletagmanager.com/gtag/js?id=G-H3KTP1DXZF"
           strategy="afterInteractive"

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -9,5 +9,6 @@
   "region_facebook": "https://www.facebook.com/f3northwestpassage",
   "region_map_lat": 29.9628818,
   "region_map_lon": -95.7796868,
-  "region_map_zoom": 12
+  "region_map_zoom": 12,
+  "admin_password": "changeme"
 }


### PR DESCRIPTION
- I've commented out Google Analytics scripts in `src/app/layout.tsx` to disable GA tracking and resolve preload warnings.
- I've added an `admin_password` field to `src/locales/en.json` with a default placeholder value.
- I've modified the API route `src/app/api/workouts/route.ts` to read the admin password from `src/locales/en.json` instead of using a hardcoded one.
- This allows the admin password for workout data modification to be configured per region via the locale JSON file.