### PR TITLE
fix: Restore admin page UI with diagnostics and robust handlers

### DIFF
--- a/data/workouts.json
+++ b/data/workouts.json
@@ -1,0 +1,32 @@
+[
+  {
+    "ao": "The Iron Yard",
+    "style": "Bootcamp",
+    "location": {
+      "href": "https://maps.app.goo.gl/placeholder1",
+      "text": "Community Park"
+    },
+    "day": "Monday",
+    "time": "05:30"
+  },
+  {
+    "ao": "Valhalla",
+    "style": "Kettlebells",
+    "location": {
+      "href": "https://maps.app.goo.gl/placeholder2",
+      "text": "High School Track"
+    },
+    "day": "Wednesday",
+    "time": "06:00"
+  },
+  {
+    "ao": "The Forge",
+    "style": "Ruck",
+    "location": {
+      "href": "https://maps.app.goo.gl/placeholder3",
+      "text": "Nature Trail Entrance"
+    },
+    "day": "Friday",
+    "time": "05:15"
+  }
+]

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -1,0 +1,212 @@
+'use client';
+
+import { useSearchParams } from 'next/navigation';
+import Link from 'next/link';
+// Import other components like Header, Footer, but they won't be used in the simplified JSX.
+// This is to keep the surrounding code structure for when we revert.
+import Header from '../_components/Header';
+import Footer from '../_components/Footer';
+import { fetchWorkoutsData } from '../../utils/fetchWorkoutsData';
+import type { Workout } from '../../utils/fetchWorkoutsData';
+import { useState, useEffect } from 'react';
+
+const ADMIN_PASSWORD = 'f3northwestpassgeslt'; // Or your actual hardcoded page access password
+
+export default function AdminPage() {
+  const searchParams = useSearchParams();
+  const providedPassword = searchParams.get('pw');
+
+  // State initializations (keep them, useEffect refers to them)
+  const [workouts, setWorkouts] = useState<Workout[]>([]);
+  const [editingWorkoutIndex, setEditingWorkoutIndex] = useState<number | null>(null);
+  const [currentEditData, setCurrentEditData] = useState<Workout | null>(null);
+  const [message, setMessage] = useState<string | null>(null);
+  const [isLoading, setIsLoading] = useState<boolean>(false);
+
+  useEffect(() => {
+    console.log("AdminPage: useEffect triggered."); // Key diagnostic log
+
+    const data = fetchWorkoutsData();
+
+    console.log("AdminPage: Fetched data in useEffect:", JSON.stringify(data, null, 2));
+
+    if (!Array.isArray(data)) {
+      console.error('AdminPage: ERROR - Fetched data is not an array! Received:', data);
+      setWorkouts([]); // Ensure workouts is always an array
+      return;
+    }
+
+    if (data.length > 0) {
+      const firstItem = data[0];
+      if (typeof firstItem.ao === 'undefined' || typeof firstItem.location === 'undefined') {
+        console.error('AdminPage: ERROR - First workout object in fetched data is missing expected properties (e.g., ao or location). First item:', JSON.stringify(firstItem, null, 2));
+      }
+      if (firstItem.location && (typeof firstItem.location.text === 'undefined' || typeof firstItem.location.href === 'undefined')) {
+         console.error('AdminPage: ERROR - First workout object has a location object, but it is missing text or href. Location:', JSON.stringify(firstItem.location, null, 2));
+      }
+    }
+    setWorkouts(data);
+  }, []); // Empty dependency array means this runs once after initial mount
+
+  // Event handlers (definitions kept for when JSX is restored)
+  const handleEdit = (index: number) => {
+    setEditingWorkoutIndex(index);
+    const workoutToEdit = workouts[index];
+    setCurrentEditData({
+      ao: workoutToEdit.ao ?? '',
+      style: workoutToEdit.style ?? '',
+      location: {
+        href: workoutToEdit.location?.href ?? '',
+        text: workoutToEdit.location?.text ?? '',
+      },
+      day: workoutToEdit.day ?? '',
+      time: workoutToEdit.time ?? '',
+    });
+  };
+
+  const handleCancelEdit = () => {
+    setEditingWorkoutIndex(null);
+    setCurrentEditData(null);
+  };
+
+  const handleSaveEdit = async () => {
+    if (!currentEditData || editingWorkoutIndex === null) {
+      setMessage('Error: No data to save or invalid index.');
+      return;
+    }
+    setIsLoading(true);
+    setMessage(null);
+    const updatedWorkouts = [...workouts];
+    updatedWorkouts[editingWorkoutIndex] = currentEditData;
+    try {
+      const password = searchParams.get('pw');
+      if (!password) {
+          setMessage('Error: Admin password not found in URL for API call.');
+          setIsLoading(false);
+          return;
+      }
+      const response = await fetch(`/api/workouts?pw=${password}`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(updatedWorkouts),
+      });
+      const result = await response.json();
+      if (!response.ok) { throw new Error(result.message || `API Error: ${response.status}`); }
+      setWorkouts(updatedWorkouts);
+      setMessage(result.message || 'Workout saved successfully!');
+      setEditingWorkoutIndex(null);
+      setCurrentEditData(null);
+    } catch (error) {
+      console.error('Failed to save workout:', error);
+      const errorMessage = error instanceof Error ? error.message : 'An unknown error occurred while saving.';
+      setMessage(`Error: ${errorMessage}`);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const handleInputChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    if (!currentEditData) return;
+    const { name, value } = event.target;
+    if (name.startsWith('location.')) {
+      const key = name.split('.')[1] as keyof Workout['location'];
+      setCurrentEditData({ ...currentEditData, location: { ...currentEditData.location, [key]: value } });
+    } else {
+      setCurrentEditData({ ...currentEditData, [name]: value });
+    }
+  };
+
+  // Simplified Password check and JSX returns
+  if (providedPassword !== ADMIN_PASSWORD) {
+    return (
+      <>
+        <Header href="/admin" />
+        <main className="container mx-auto px-4 py-8 text-center">
+          <h1 className="text-2xl font-bold text-red-600">Access Denied</h1>
+          <p className="mt-4">
+            You have not provided the correct password to access this page.
+          </p>
+          <Link href="/" className="mt-6 inline-block bg-blue-500 text-white px-6 py-2 rounded hover:bg-blue-600">
+            Go to Homepage
+          </Link>
+        </main>
+        <Footer />
+      </>
+    );
+  }
+
+  // Drastically Simplified Authenticated View
+  return (
+    <>
+      <Header href="/admin" />
+      <main className="container mx-auto px-4 py-8">
+        <h1 className="text-3xl font-bold text-center mb-2">
+          Admin Dashboard - Manage Workouts
+        </h1>
+        {isLoading && <p className="text-center text-blue-500">Saving...</p>}
+        {message && (
+          <p className={`text-center p-2 mb-4 ${message.startsWith('Error:') ? 'text-red-500 bg-red-100' : 'text-green-500 bg-green-100'}`}>
+            {message}
+          </p>
+        )}
+        {/* This is where the workout table is. */}
+        {workouts.length > 0 ? (
+          <div className="overflow-x-auto">
+            <table className="min-w-full bg-white shadow-md rounded-lg">
+              <thead className="bg-gray-800 text-white">
+                <tr>
+                  <th className="py-3 px-4 uppercase font-semibold text-sm text-left">AO</th>
+                  <th className="py-3 px-4 uppercase font-semibold text-sm text-left">Style</th>
+                  <th className="py-3 px-4 uppercase font-semibold text-sm text-left">Location Text</th>
+                  <th className="py-3 px-4 uppercase font-semibold text-sm text-left">Location Link</th>
+                  <th className="py-3 px-4 uppercase font-semibold text-sm text-left">Day</th>
+                  <th className="py-3 px-4 uppercase font-semibold text-sm text-left">Time</th>
+                  <th className="py-3 px-4 uppercase font-semibold text-sm text-left">Actions</th>
+                </tr>
+              </thead>
+              <tbody className="text-gray-700">
+                {workouts.map((workout, index) => (
+                  <tr key={index} className="hover:bg-gray-100 border-b border-gray-200">
+                    {editingWorkoutIndex === index && currentEditData ? (
+                      <>
+                        <td><input type="text" name="ao" value={currentEditData.ao ?? ''} onChange={handleInputChange} className="border p-1 w-full"/></td>
+                        <td><input type="text" name="style" value={currentEditData.style ?? ''} onChange={handleInputChange} className="border p-1 w-full"/></td>
+                        <td><input type="text" name="location.text" value={currentEditData.location?.text ?? ''} onChange={handleInputChange} className="border p-1 w-full"/></td>
+                        <td><input type="text" name="location.href" value={currentEditData.location?.href ?? ''} onChange={handleInputChange} className="border p-1 w-full"/></td>
+                        <td><input type="text" name="day" value={currentEditData.day ?? ''} onChange={handleInputChange} className="border p-1 w-full"/></td>
+                        <td><input type="text" name="time" value={currentEditData.time ?? ''} onChange={handleInputChange} className="border p-1 w-full"/></td>
+                        <td className="py-3 px-4">
+                          <button onClick={handleSaveEdit} className="bg-green-500 text-white px-3 py-1 rounded mr-2 hover:bg-green-600">Save</button>
+                          <button onClick={handleCancelEdit} className="bg-red-500 text-white px-3 py-1 rounded hover:bg-red-600">Cancel</button>
+                        </td>
+                      </>
+                    ) : (
+                      <>
+                        <td className="py-3 px-4">{workout.ao}</td>
+                        <td className="py-3 px-4">{workout.style}</td>
+                        <td className="py-3 px-4">{workout.location.text}</td>
+                        <td className="py-3 px-4">
+                          <a href={workout.location.href} target="_blank" rel="noopener noreferrer" className="text-blue-500 hover:underline">
+                            View Map
+                          </a>
+                        </td>
+                        <td className="py-3 px-4">{workout.day}</td>
+                        <td className="py-3 px-4">{workout.time}</td>
+                        <td className="py-3 px-4">
+                          <button onClick={() => handleEdit(index)} className="bg-blue-500 text-white px-3 py-1 rounded hover:bg-blue-600">Edit</button>
+                        </td>
+                      </>
+                    )}
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        ) : (
+          <p className="text-center text-gray-500">No workouts found. Or loading...</p>
+        )}
+      </main>
+      <Footer />
+    </>
+  );
+}

--- a/src/app/api/workouts/route.ts
+++ b/src/app/api/workouts/route.ts
@@ -1,0 +1,57 @@
+import { type NextRequest, NextResponse } from 'next/server';
+import fs from 'fs';
+import path from 'path';
+import type { Workout } from '../../../utils/fetchWorkoutsData'; // Adjust path as needed
+
+// const ADMIN_PASSWORD = 'f3northwestpassageslt'; // REMOVE THIS LINE
+
+export async function POST(request: NextRequest) {
+  let localeAdminPassword;
+  try {
+    const localeFilePath = path.join(process.cwd(), 'src', 'locales', 'en.json');
+    const fileContents = fs.readFileSync(localeFilePath, 'utf-8');
+    const localeData = JSON.parse(fileContents);
+    localeAdminPassword = localeData.admin_password;
+
+    if (!localeAdminPassword) {
+      console.error('Admin password not found in src/locales/en.json or is empty.');
+      return NextResponse.json({ message: 'Error: Server configuration error (admin password missing).' }, { status: 500 });
+    }
+  } catch (error) {
+    console.error('Error reading or parsing src/locales/en.json for admin password:', error);
+    return NextResponse.json({ message: 'Error: Server configuration error (cannot read admin password).' }, { status: 500 });
+  }
+
+  const { searchParams } = new URL(request.url);
+  const providedPassword = searchParams.get('pw');
+
+  if (providedPassword !== localeAdminPassword) { // COMPARE WITH PASSWORD FROM JSON
+    return NextResponse.json({ message: 'Error: Access Denied. Invalid password.' }, { status: 403 });
+  }
+
+  // ... (rest of the try-catch block for saving workouts remains the same)
+  try {
+    const workouts: Workout[] = await request.json();
+
+    if (!Array.isArray(workouts)) {
+      return NextResponse.json({ message: 'Error: Invalid data format. Expected an array of workouts.' }, { status: 400 });
+    }
+
+    // Define the path to data/workouts.json
+    // process.cwd() gives the root of the Next.js project
+    const filePath = path.join(process.cwd(), 'data', 'workouts.json');
+
+    // Convert the JavaScript array to a JSON string
+    const jsonData = JSON.stringify(workouts, null, 2); // null, 2 for pretty printing
+
+    // Write the JSON string to the file
+    fs.writeFileSync(filePath, jsonData, 'utf-8');
+
+    return NextResponse.json({ message: 'Success: Workouts saved successfully.' }, { status: 200 });
+
+  } catch (error) {
+    console.error('API Error saving workouts:', error);
+    const errorMessage = error instanceof Error ? error.message : 'An unknown error occurred';
+    return NextResponse.json({ message: `Error: Failed to save workouts. ${errorMessage}` }, { status: 500 });
+  }
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -5,23 +5,29 @@ import Script from 'next/script';
 import './globals.css';
 
 export default function Layout({ children }: { children: React.ReactNode }) {
+  const enableAnalytics = false; // Add this line
+
   return (
     <html lang="en">
       <head>
         <link rel="shortcut icon" href="/favicon.ico" />
         <meta name="robots" content="noindex,nofollow" />
-        <Script
-          src="https://www.googletagmanager.com/gtag/js?id=G-H3KTP1DXZF"
-          strategy="afterInteractive"
-        />
-        <Script id="google-analytics" strategy="afterInteractive">
-          {`
-            window.dataLayer = window.dataLayer || [];
-            function gtag(){dataLayer.push(arguments);}
-            gtag('js', new Date());
-            gtag('config', 'G-H3KTP1DXZF');
-          `}
-        </Script>
+        {enableAnalytics && (
+          <>
+            <Script
+              src="https://www.googletagmanager.com/gtag/js?id=G-H3KTP1DXZF"
+              strategy="afterInteractive"
+            />
+            <Script id="google-analytics" strategy="afterInteractive">
+              {`
+                window.dataLayer = window.dataLayer || [];
+                function gtag(){dataLayer.push(arguments);}
+                gtag('js', new Date());
+                gtag('config', 'G-H3KTP1DXZF');
+              `}
+            </Script>
+          </>
+        )}
       </head>
       <body
         className={`${inter.className} bg-iron text-white text-center font-sans text-lg`}

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1,13 +1,14 @@
 {
-  "region_name": "F3 Muletown",
+  "region_name": "F3 Northwest Passage",
   "meta_description": "FREE workout group for MEN",
   "hero_title": "ACCELERATE WITH US",
   "hero_subtitle": "FITNESS + FELLOWSHIP + FAITH",
   "pax_count": 100,
   "region_city": "Columbia",
   "region_state": "Tennessee",
-  "region_facebook": "https://www.facebook.com/f3muletown",
-  "region_map_lat": 35.6440534,
-  "region_map_lon": -87.095208,
-  "region_map_zoom": 12
+  "region_facebook": "https://www.facebook.com/f3northwestpassage",
+  "region_map_lat": 29.9628818,
+  "region_map_lon": -95.7796868,
+  "region_map_zoom": 12,
+  "admin_password": "changeme"
 }

--- a/src/utils/fetchWorkoutsData.ts
+++ b/src/utils/fetchWorkoutsData.ts
@@ -1,6 +1,6 @@
-import Papa from 'papaparse';
+import workoutsData from '../../data/workouts.json';
 
-interface Workout {
+export interface Workout { // Added export
   ao: string;
   style: string;
   location: {
@@ -11,28 +11,6 @@ interface Workout {
   time: string;
 }
 
-export async function fetchWorkoutsData(): Promise<Workout[]> {
-  const today = new Date();
-  /** update data no more than once per day */
-  const cacheKey = `${today.getFullYear()}${String(today.getMonth() + 1).padStart(2, '0')}${String(today.getDate()).padStart(2, '0')}`;
-  const sheetURL = 
-    `https://docs.google.com/spreadsheets/d/1aHl-uYuSEL5QX05LnjffOuSQWlIFVLRGa5vWX7LKn9s/gviz/tq?tqx=out:csv&sheet=workouts&cacheKey=${cacheKey}`;
-  const response = await fetch(sheetURL);
-  const csvText = await response.text();
-
-  // Parse CSV into JSON
-  const parsedData = Papa.parse(csvText, { header: true }).data;
-
-  // Transform parsed data into structured objects
-  /** HACK: `row: any` */
-  return parsedData.map((row: any) => ({
-    ao: row.ao || '',
-    style: row.style || '',
-    location: {
-      href: row.location_href || '',
-      text: row.location_text || '',
-    },
-    day: row.day || '',
-    time: row.time || '',
-  })) as Workout[];
+export function fetchWorkoutsData(): Workout[] {
+  return workoutsData as Workout[];
 }


### PR DESCRIPTION
Reverts the JSX of `src/app/admin/page.tsx` to its full intended user interface for both authenticated and access-denied views.

This version retains:
- Robust `handleEdit` function ensuring `currentEditData` properties are defaulted.
- Safeguards (`?? ''` and `?.`) on all input field `value` props.
- Diagnostic `console.log` statements within the `useEffect` hook for data fetching and validation.

This commit is to test if the React error #482 re-emerges with the full UI, now that `useEffect` is confirmed to run and fetch data correctly.