### PR TITLE
fix: Align admin page access password with en.json default

### DIFF
--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -10,7 +10,7 @@ import { fetchWorkoutsData } from '../../utils/fetchWorkoutsData';
 import type { Workout } from '../../utils/fetchWorkoutsData';
 import { useState, useEffect } from 'react';
 
-const ADMIN_PASSWORD = 'f3northwestpassgeslt'; // Or your actual hardcoded page access password
+const ADMIN_PASSWORD = 'changeme';
 
 export default function AdminPage() {
   const searchParams = useSearchParams();


### PR DESCRIPTION
Changes the hardcoded `ADMIN_PASSWORD` constant in `src/app/admin/page.tsx` to 'changeme'. This aligns the page access password with the current default value stored in `src/locales/en.json`, which is used by the API for authentication.

This should resolve the issue where valid users like you providing `?pw=changeme` were still seeing 'Access Denied' on the admin page.